### PR TITLE
snapcraft.yaml: correct capitalization for 'version'

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,7 @@ parts:
       - git
     override-build: |
       VERSION=$(craftctl get version)
-      LDFLAGS="-X github.com/canonical/snap-tpmctl/cmd/tpmctl/cmd.Version=$VERSION"
+      LDFLAGS="-X github.com/canonical/snap-tpmctl/cmd/tpmctl/cmd.version=$VERSION"
       go build -ldflags="$LDFLAGS" -o $CRAFT_PART_INSTALL/bin/snap-tpmctl ./cmd/tpmctl
     after:
       - version


### PR DESCRIPTION
Closes #61

LDFLAGS is used to override global variable 'version'. This requires that the LDFLAGS capitalization of the variable matches the code.